### PR TITLE
feat: clamp Activity chart bars to zero and promote to top slot [P4.01]

### DIFF
--- a/src/lib/components/BarChart/barChartHelpers.spec.ts
+++ b/src/lib/components/BarChart/barChartHelpers.spec.ts
@@ -36,6 +36,62 @@ describe('createActiveHoursData', () => {
 
     const result = createActiveHoursData(durations)
     const values = result.map((item) => item.value)
+    expect(values[10]).toBe(0)
     expect(values.every((v) => v >= 0)).toBe(true)
+  })
+
+  it('clamps same-hour accumulation at zero when a reversed segment exceeds prior minutes', () => {
+    const durations: SupabaseDuration = {
+      id: 'test',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+      date: '2024-01-01',
+      data: [
+        {
+          time: 1704103200, // 2024-01-01 10:00 AM UTC
+          duration: 1200, // +20 minutes
+          color: null,
+          project: 'test',
+          language: 'TypeScript',
+          category: 'coding',
+          entity: 'test.ts',
+          branch: 'main',
+          ai_session: null,
+          ai_additions: 0,
+          ai_deletions: 0,
+          human_additions: 0,
+          human_deletions: 0,
+          ai_input_tokens: 0,
+          ai_output_tokens: 0,
+          ai_prompt_length_sum: 0,
+          ai_prompt_events: 0,
+        },
+        {
+          time: 1704105000, // 2024-01-01 10:30 AM UTC
+          duration: -1800, // -30 minutes, would underflow without clamping acc + delta
+          color: null,
+          project: 'test',
+          language: 'TypeScript',
+          category: 'coding',
+          entity: 'test.ts',
+          branch: 'main',
+          ai_session: null,
+          ai_additions: 0,
+          ai_deletions: 0,
+          human_additions: 0,
+          human_deletions: 0,
+          ai_input_tokens: 0,
+          ai_output_tokens: 0,
+          ai_prompt_length_sum: 0,
+          ai_prompt_events: 0,
+        },
+      ],
+    }
+
+    const result = createActiveHoursData(durations)
+    const values = result.map((item) => item.value)
+
+    expect(values[10]).toBe(0)
+    expect(values.every((value, index) => index === 10 || value === 0)).toBe(true)
   })
 })

--- a/src/lib/components/BarChart/barChartHelpers.spec.ts
+++ b/src/lib/components/BarChart/barChartHelpers.spec.ts
@@ -1,0 +1,41 @@
+import type { SupabaseDuration } from '$src/routes/api/supabase/durations/+server'
+import { describe, expect, it } from 'vitest'
+import { createActiveHoursData } from './barChartHelpers'
+
+describe('createActiveHoursData', () => {
+  it('never returns a bar value below zero for reversed duration segments', () => {
+    // A duration where end < start (same hour): time=10:30, duration=-1800s → ends at 10:00
+    // endTime.diff(startTime, 'minutes') produces -30, accumulating a negative bar.
+    const durations: SupabaseDuration = {
+      id: 'test',
+      created_at: '2024-01-01',
+      updated_at: '2024-01-01',
+      date: '2024-01-01',
+      data: [
+        {
+          time: 1704105000, // 2024-01-01 10:30 AM UTC
+          duration: -1800, // reversed: ends at 10:00 AM
+          color: null,
+          project: 'test',
+          language: 'TypeScript',
+          category: 'coding',
+          entity: 'test.ts',
+          branch: 'main',
+          ai_session: null,
+          ai_additions: 0,
+          ai_deletions: 0,
+          human_additions: 0,
+          human_deletions: 0,
+          ai_input_tokens: 0,
+          ai_output_tokens: 0,
+          ai_prompt_length_sum: 0,
+          ai_prompt_events: 0,
+        },
+      ],
+    }
+
+    const result = createActiveHoursData(durations)
+    const values = result.map((item) => item.value)
+    expect(values.every((v) => v >= 0)).toBe(true)
+  })
+})

--- a/src/lib/components/BarChart/barChartHelpers.ts
+++ b/src/lib/components/BarChart/barChartHelpers.ts
@@ -223,7 +223,7 @@ export const createActiveHoursData = (durations: SupabaseDuration) =>
       const endHour = endTime.hour()
 
       if (startHour === endHour) {
-        acc[startHour] += endTime.diff(startTime, 'minutes')
+        acc[startHour] = Math.max(0, acc[startHour] + endTime.diff(startTime, 'minutes'))
         return acc
       }
 
@@ -236,7 +236,7 @@ export const createActiveHoursData = (durations: SupabaseDuration) =>
         const lowerMinute = startInterval.isBefore(startTime) ? startTime.minute() : 0
         const upperMinute = endInterval.isBefore(endTime) ? 60 : endTime.minute()
         const deltaMinutes = upperMinute - lowerMinute
-        acc[hour] += deltaMinutes
+        acc[hour] = Math.max(0, acc[hour] + deltaMinutes)
       }
       return acc
     }, Array(24).fill(0))

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -60,6 +60,7 @@
   <div class="flex justify-end">
     <DateRangeSelect on:wakarange={onWakaRange} />
   </div>
+  <ActivityChart {durations} itemType="project" />
   <StatsPanel {summaries} showFullPanel />
   <div class="overflow-x-auto">
     <div class="stats bg-chart-dark shadow-lg">
@@ -74,7 +75,6 @@
     </div>
   </div>
   <AiActivityChart data={aiData} />
-  <ActivityChart {durations} itemType="project" />
   <div class="grid grid-cols-1 gap-4 lg:grid-cols-2">
     <BreakdownChart {summaries} title="Project Breakdown" />
     {#if $selectedRange !== WakaApiRange.Today && $selectedRange !== WakaApiRange.Yesterday}


### PR DESCRIPTION
## Summary

- delivery ticket: `P4.01 Activity chart clamp + promote to top slot`
- ticket file: [docs/02-delivery/phase-04/ticket-01-activity-chart-fix.md](https://github.com/cesarnml/coding-stats/blob/main/docs/02-delivery/phase-04/ticket-01-activity-chart-fix.md)
- stacked base branch: `main`
- self-audit: outcome `clean` completed at 2026-05-03 20:03 UTC
- codexPreflight: outcome `patched` completed at 2026-05-03 20:07 UTC

### Codex Preflight Patch Commits

- [`c5ca145`](https://github.com/cesarnml/coding-stats/commit/c5ca145) test(P4.01): strengthen clamp assertions with overflow and precise value checks [codexPreflight]
