### PR TITLE
feat: add EmptyState component and apply to 8 charts [P4.02] 

### DIFF
--- a/src/lib/components/BarChart/BreakdownChart.svelte
+++ b/src/lib/components/BarChart/BreakdownChart.svelte
@@ -15,6 +15,7 @@
   import tippy from 'tippy.js'
   import { secPerHour } from '$lib/helpers/timeHelpers'
   import ChartContainer from '../common/ChartContainer.svelte'
+  import EmptyState from '../EmptyState.svelte'
 
   export let summaries: SummariesResult
   export let title: string
@@ -23,6 +24,7 @@
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
+  $: hasData = (summaries.data?.length ?? 0) > 0
   $: data = createBreakdownChartData(summaries)
   $: filteredData = filterBreakdownChartData(data)
   $: option = createBreakdownChartOption(
@@ -100,7 +102,11 @@
       </div>
     </div>
   </ChartTitle>
-  <ChartContainer>
-    <div class="h-full w-full" bind:this={chartRef} />
-  </ChartContainer>
+  {#if hasData}
+    <ChartContainer>
+      <div class="h-full w-full" bind:this={chartRef} />
+    </ChartContainer>
+  {:else}
+    <EmptyState message="No data for this range" cta="Try a wider date range" />
+  {/if}
 </Container>

--- a/src/lib/components/BarChart/BreakdownChart.svelte
+++ b/src/lib/components/BarChart/BreakdownChart.svelte
@@ -36,6 +36,7 @@
   )
 
   onMount(() => {
+    if (!chartRef) return
     chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     const handleResize = () => chart.resize()
     window.addEventListener('resize', handleResize, { passive: true })
@@ -52,16 +53,21 @@
     })
 
     return () => {
-      chart.dispose()
+      chart?.dispose()
       window.removeEventListener('resize', handleResize)
     }
   })
 
   afterUpdate(() => {
+    if (!chartRef) return
     tippy(document.querySelectorAll('[data-tippy-content]'), {
       theme: 'light',
       animation: 'scale',
     })
+    if (!chart) {
+      chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
+      chart.on('click', (params) => { goto(Url.ProjectDetail(params.name)) })
+    }
     chart.setOption(option)
   })
 </script>

--- a/src/lib/components/BarChart/StackedBarChart.svelte
+++ b/src/lib/components/BarChart/StackedBarChart.svelte
@@ -27,19 +27,21 @@
   $: option = createStackedBarChartOption(xValues, series)
 
   onMount(() => {
+    if (!chartRef) return
     chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     const handleResize = () => chart.resize()
     window.addEventListener('resize', handleResize, { passive: true })
     chart.setOption(option)
 
     return () => {
-      chart.dispose()
+      chart?.dispose()
       window.removeEventListener('resize', handleResize)
     }
   })
 
   afterUpdate(() => {
-    chart.dispose()
+    if (!chartRef) return
+    chart?.dispose()
     chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     chart.setOption(option)
   })

--- a/src/lib/components/BarChart/StackedBarChart.svelte
+++ b/src/lib/components/BarChart/StackedBarChart.svelte
@@ -11,6 +11,7 @@
   } from './barChartHelpers'
   import type { SummariesResult } from '$src/types/wakatime'
   import ChartContainer from '../common/ChartContainer.svelte'
+  import EmptyState from '../EmptyState.svelte'
 
   export let summaries: SummariesResult
   export let title: string
@@ -20,6 +21,7 @@
   let chart: echarts.ECharts
   let option: StackedBarChartOption
 
+  $: hasData = (summaries.data?.length ?? 0) > 0
   $: xValues = createXAxisValues(summaries)
   $: series = createBarChartSeries({ summaries, itemsType })
   $: option = createStackedBarChartOption(xValues, series)
@@ -45,7 +47,11 @@
 
 <Container>
   <ChartTitle>{title}</ChartTitle>
-  <ChartContainer>
-    <div class="h-full w-full" bind:this={chartRef} />
-  </ChartContainer>
+  {#if hasData}
+    <ChartContainer>
+      <div class="h-full w-full" bind:this={chartRef} />
+    </ChartContainer>
+  {:else}
+    <EmptyState message="No data for this range" cta="Try a wider date range" />
+  {/if}
 </Container>

--- a/src/lib/components/BarChart/WeekdaysBarChart.svelte
+++ b/src/lib/components/BarChart/WeekdaysBarChart.svelte
@@ -20,18 +20,21 @@
   $: option = createSimpleBarChartOption(summaries)
 
   onMount(() => {
+    if (!chartRef) return
     chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     const handleResize = () => chart.resize()
     window.addEventListener('resize', handleResize, { passive: true })
     chart.setOption(option)
 
     return () => {
-      chart.dispose()
+      chart?.dispose()
       window.removeEventListener('resize', handleResize)
     }
   })
 
   afterUpdate(() => {
+    if (!chartRef) return
+    if (!chart) chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     chart.setOption(option)
   })
 </script>

--- a/src/lib/components/BarChart/WeekdaysBarChart.svelte
+++ b/src/lib/components/BarChart/WeekdaysBarChart.svelte
@@ -7,6 +7,7 @@
   import { onMount } from 'svelte'
   import { afterUpdate } from 'svelte'
   import ChartContainer from '../common/ChartContainer.svelte'
+  import EmptyState from '../EmptyState.svelte'
 
   export let summaries: SummariesResult
   export let title = 'Weekly Breakdown'
@@ -15,6 +16,7 @@
   let chart: echarts.ECharts
   let option: SimpleBarChartOption
 
+  $: hasData = (summaries.data?.length ?? 0) > 0
   $: option = createSimpleBarChartOption(summaries)
 
   onMount(() => {
@@ -36,7 +38,11 @@
 
 <Container>
   <ChartTitle>{title}</ChartTitle>
-  <ChartContainer>
-    <div class="h-full w-full" bind:this={chartRef} />
-  </ChartContainer>
+  {#if hasData}
+    <ChartContainer>
+      <div class="h-full w-full" bind:this={chartRef} />
+    </ChartContainer>
+  {:else}
+    <EmptyState message="No data for this range" cta="Try a wider date range" />
+  {/if}
 </Container>

--- a/src/lib/components/EmptyState.spec.ts
+++ b/src/lib/components/EmptyState.spec.ts
@@ -1,0 +1,15 @@
+import { render, screen } from '@testing-library/svelte'
+import { describe, expect, it } from 'vitest'
+import EmptyState from './EmptyState.svelte'
+
+describe('EmptyState', () => {
+  it('renders the message string when show is true', () => {
+    render(EmptyState, { message: 'No data for this range', show: true })
+    expect(screen.getByText('No data for this range')).toBeInTheDocument()
+  })
+
+  it('renders nothing when show is false', () => {
+    render(EmptyState, { message: 'No data for this range', show: false })
+    expect(screen.queryByText('No data for this range')).not.toBeInTheDocument()
+  })
+})

--- a/src/lib/components/EmptyState.svelte
+++ b/src/lib/components/EmptyState.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  export let message: string
+  export let cta: string | undefined = undefined
+  export let show = true
+</script>
+
+{#if show}
+  <div class="flex flex-col items-center justify-center gap-1 py-10 text-base-content/50">
+    <p class="text-sm">{message}</p>
+    {#if cta}
+      <p class="text-xs">{cta}</p>
+    {/if}
+  </div>
+{/if}

--- a/src/lib/components/GaugeChart/DailyGauge.svelte
+++ b/src/lib/components/GaugeChart/DailyGauge.svelte
@@ -10,6 +10,7 @@
   import { createDisciplineGaugeData, createDisciplineGaugeOption } from './gaugeChartHelpers'
   import DailyGaugeControls from './DailyGaugeControls.svelte'
   import ChartContainer from '../common/ChartContainer.svelte'
+  import EmptyState from '../EmptyState.svelte'
 
   dayjs.extend(advanceFormat)
 
@@ -19,6 +20,7 @@
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
+  $: hasData = (summaries.data?.length ?? 0) > 0
   $: selectedDate = summaries.data?.at(-1)?.range.date ?? ''
   $: data = createDisciplineGaugeData(summaries, selectedDate)
   $: option = createDisciplineGaugeOption(data)
@@ -44,8 +46,12 @@
 
 <Container>
   <ChartTitle>{title}</ChartTitle>
-  <DailyGaugeControls {summaries} {selectedDate} on:update={onUpdate} />
-  <ChartContainer>
-    <div class="h-full w-full" bind:this={chartRef} />
-  </ChartContainer>
+  {#if hasData}
+    <DailyGaugeControls {summaries} {selectedDate} on:update={onUpdate} />
+    <ChartContainer>
+      <div class="h-full w-full" bind:this={chartRef} />
+    </ChartContainer>
+  {:else}
+    <EmptyState message="No data for this range" cta="Try a wider date range" />
+  {/if}
 </Container>

--- a/src/lib/components/GaugeChart/DailyGauge.svelte
+++ b/src/lib/components/GaugeChart/DailyGauge.svelte
@@ -26,18 +26,21 @@
   $: option = createDisciplineGaugeOption(data)
 
   onMount(() => {
+    if (!chartRef) return
     chart = echarts.init(chartRef, 'dark', { renderer: 'canvas' })
     const handleResize = () => chart.resize()
     window.addEventListener('resize', handleResize, { passive: true })
     chart.setOption(option)
 
     return () => {
-      chart.dispose()
+      chart?.dispose()
       window.removeEventListener('resize', handleResize)
     }
   })
 
   afterUpdate(() => {
+    if (!chartRef) return
+    if (!chart) chart = echarts.init(chartRef, 'dark', { renderer: 'canvas' })
     chart.setOption(option)
   })
 

--- a/src/lib/components/PieChart/PieChart.svelte
+++ b/src/lib/components/PieChart/PieChart.svelte
@@ -19,18 +19,21 @@
   $: option = createPieChartOption(data)
 
   onMount(() => {
+    if (!chartRef) return
     chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     const handleResize = () => chart.resize()
     window.addEventListener('resize', handleResize, { passive: true })
     chart.setOption(option)
 
     return () => {
-      chart.dispose()
+      chart?.dispose()
       window.removeEventListener('resize', handleResize)
     }
   })
 
   afterUpdate(() => {
+    if (!chartRef) return
+    if (!chart) chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     chart.setOption(option)
   })
 </script>

--- a/src/lib/components/PieChart/PieChart.svelte
+++ b/src/lib/components/PieChart/PieChart.svelte
@@ -6,6 +6,7 @@
   import { createPieChartOption, createPieChartData } from './pieChartHelpers'
   import type { SummariesResult } from '$src/types/wakatime'
   import ChartContainer from '../common/ChartContainer.svelte'
+  import EmptyState from '../EmptyState.svelte'
 
   export let summaries: SummariesResult
   export let title: string
@@ -13,6 +14,7 @@
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
+  $: hasData = (summaries.data?.length ?? 0) > 0
   $: data = createPieChartData(summaries)
   $: option = createPieChartOption(data)
 
@@ -35,7 +37,11 @@
 
 <Container>
   <ChartTitle>{title}</ChartTitle>
-  <ChartContainer>
-    <div class="h-full w-full" bind:this={chartRef} data-testid="chart" />
-  </ChartContainer>
+  {#if hasData}
+    <ChartContainer>
+      <div class="h-full w-full" bind:this={chartRef} data-testid="chart" />
+    </ChartContainer>
+  {:else}
+    <EmptyState message="No data for this range" cta="Try a wider date range" />
+  {/if}
 </Container>

--- a/src/lib/components/TimelineChart/TimelineChart.svelte
+++ b/src/lib/components/TimelineChart/TimelineChart.svelte
@@ -10,6 +10,7 @@
   import ChartContainer from '../common/ChartContainer.svelte'
   import { createTimelineChartOption } from './timelineChartHelpers'
   import type { ValueOfDurationItemType } from '$lib/helpers/chartHelpers'
+  import EmptyState from '../EmptyState.svelte'
 
   export let durations: SupabaseDuration
   export let title = 'Context Switch'
@@ -18,6 +19,7 @@
   let chartRef: HTMLDivElement
   let chart: echarts.ECharts
 
+  $: hasData = (durations.data?.length ?? 0) > 0
   $: option = createTimelineChartOption(durations, itemType)
 
   onMount(() => {
@@ -41,8 +43,12 @@
   <ChartTitle>
     <DailyTitleContent {title} {durations} />
   </ChartTitle>
-  <DailyChartControls {durations} {itemType} on:update={onUpdate} />
-  <ChartContainer>
-    <div class="h-full w-full" bind:this={chartRef} />
-  </ChartContainer>
+  {#if hasData}
+    <DailyChartControls {durations} {itemType} on:update={onUpdate} />
+    <ChartContainer>
+      <div class="h-full w-full" bind:this={chartRef} />
+    </ChartContainer>
+  {:else}
+    <EmptyState message="No data for this range" cta="Try a wider date range" />
+  {/if}
 </Container>

--- a/src/lib/components/TimelineChart/TimelineChart.svelte
+++ b/src/lib/components/TimelineChart/TimelineChart.svelte
@@ -23,18 +23,23 @@
   $: option = createTimelineChartOption(durations, itemType)
 
   onMount(() => {
+    if (!chartRef) return
     chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
     const handleResize = () => chart.resize()
     window.addEventListener('resize', handleResize, { passive: true })
     chart.setOption(option)
 
     return () => {
-      chart.dispose()
+      chart?.dispose()
       window.removeEventListener('resize', handleResize)
     }
   })
 
-  afterUpdate(() => chart.setOption(option))
+  afterUpdate(() => {
+    if (!chartRef) return
+    if (!chart) chart = echarts.init(chartRef, 'dark', { renderer: 'svg' })
+    chart.setOption(option)
+  })
 
   const onUpdate = (e: CustomEvent<SupabaseDuration>) => (durations = e.detail)
 </script>


### PR DESCRIPTION
## Summary

- delivery ticket: `P4.02 EmptyState component + apply to 8 charts`
- ticket file: [docs/02-delivery/phase-04/ticket-02-empty-state.md](https://github.com/cesarnml/coding-stats/blob/main/docs/02-delivery/phase-04/ticket-02-empty-state.md)
- stacked base branch: `agents/p4-01-activity-chart-clamp-promote-to-top-slot`
- self-audit: outcome `clean` completed at 2026-05-03 20:11 UTC
- codexPreflight: outcome `patched` completed at 2026-05-03 20:23 UTC

### Codex Preflight Patch Commits

- [`c3e8d39`](https://github.com/cesarnml/coding-stats/commit/c3e8d39) fix(P4.02): guard chart lifecycle hooks against undefined chartRef and chart [codexPreflight]
