### PR TITLE
feat(P4.04): data freshness signal

### DIFF
--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,7 +1,7 @@
 import { ApiEndpoint, WakaApiRange } from '$lib/constants'
-import type { SummariesResult } from '$src/types/wakatime'
 import type { PageServerLoad } from './$types'
 import type { SupabaseDuration } from './api/supabase/durations/+server'
+import type { SummariesApiResponse } from './api/supabase/summaries/+server'
 
 export const load: PageServerLoad = async ({ fetch, url, locals: { getProfile } }) => {
   const profile = await getProfile()
@@ -14,7 +14,7 @@ export const load: PageServerLoad = async ({ fetch, url, locals: { getProfile } 
     fetch(ApiEndpoint.SupabaseDurationsByLanguage),
   ])
 
-  const summaries = (await summariesResponse.json()) as SummariesResult
+  const summaries = (await summariesResponse.json()) as SummariesApiResponse
   const durations = (await durationsResponse.json()) as SupabaseDuration
   const durationsByLanguage = (await durationsByLanguageResponse.json()) as SupabaseDuration
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -27,7 +27,7 @@
 
   $: ({ summaries, durations, durationsByLanguage, profile } = data)
 
-  $: maxDate = (summaries as typeof summaries & { max_date: string | null }).max_date ?? null
+  $: maxDate = summaries.max_date ?? null
   $: maxDateFormatted = maxDate ? dayjs(maxDate).format(DateFormat.Shortish) : null
 
   $: aiStats = summaries.data.reduce(

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -13,8 +13,10 @@
   import AiTokenBarChart from '$lib/components/AiTokenBarChart/AiTokenBarChart.svelte'
   import TimelineChart from '$lib/components/TimelineChart/TimelineChart.svelte'
   import { ApiEndpoint, WakaApiRange, type ValueOf } from '$lib/constants'
+  import { DateFormat } from '$lib/helpers/timeHelpers'
   import { loading } from '$lib/stores/loading'
   import { selectedRange } from '$lib/stores/selectedRange'
+  import dayjs from 'dayjs'
   import { onMount } from 'svelte'
   import type { PageData } from './$types'
   import { invalidate } from '$app/navigation'
@@ -24,6 +26,9 @@
   let { summaries, durations, durationsByLanguage, profile } = data
 
   $: ({ summaries, durations, durationsByLanguage, profile } = data)
+
+  $: maxDate = (summaries as typeof summaries & { max_date: string | null }).max_date ?? null
+  $: maxDateFormatted = maxDate ? dayjs(maxDate).format(DateFormat.Shortish) : null
 
   $: aiStats = summaries.data.reduce(
     (acc, day) => {
@@ -70,7 +75,12 @@
 </svelte:head>
 
 <div class="space-y-4 px-2 md:px-4">
-  <div class="flex justify-end">
+  <div class="flex items-center justify-between">
+    <div>
+      {#if maxDateFormatted}
+        <p class="text-xs text-base-content/50">Data through {maxDateFormatted}</p>
+      {/if}
+    </div>
     <DateRangeSelect on:wakarange={onWakaRange} />
   </div>
   <ActivityChart {durations} itemType="project" />

--- a/src/routes/api/supabase/summaries/+server.ts
+++ b/src/routes/api/supabase/summaries/+server.ts
@@ -4,6 +4,8 @@ import type { SummariesResult } from '$src/types/wakatime'
 import { json, type RequestHandler } from '@sveltejs/kit'
 import dayjs from 'dayjs'
 
+export type SummariesApiResponse = SummariesResult & { max_date: string | null }
+
 export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
   const start = url.searchParams.get('start') ?? ''
   const end = url.searchParams.get('end') ?? ''
@@ -23,7 +25,7 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
       ? dayjs().utc().subtract(1, 'd').format(DateFormat.Query)
       : dayjs().utc().format(DateFormat.Query)
 
-  const [{ data: summariesData }, { data: maxDateData }] = await Promise.all([
+  const [summariesRes, maxDateRes] = await Promise.all([
     supabase
       .from('summaries')
       .select('*')
@@ -33,10 +35,20 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
     supabase.from('summaries').select('date').order('date', { ascending: false }).limit(1),
   ])
 
+  if (summariesRes.error || maxDateRes.error) {
+    return json(
+      {
+        error: 'Failed to fetch summaries',
+        details: summariesRes.error?.message ?? maxDateRes.error?.message,
+      },
+      { status: 500 },
+    )
+  }
+
   const summaries = {
-    data: summariesData,
-    max_date: maxDateData?.[0]?.date ?? null,
-  } as unknown as SummariesResult & { max_date: string | null }
+    data: summariesRes.data,
+    max_date: maxDateRes.data?.[0]?.date ?? null,
+  } as unknown as SummariesApiResponse
 
   return json(summaries)
 }

--- a/src/routes/api/supabase/summaries/+server.ts
+++ b/src/routes/api/supabase/summaries/+server.ts
@@ -23,16 +23,20 @@ export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
       ? dayjs().utc().subtract(1, 'd').format(DateFormat.Query)
       : dayjs().utc().format(DateFormat.Query)
 
-  const { data: summariesData } = await supabase
-    .from('summaries')
-    .select('*')
-    .gte('date', rangeStart)
-    .lte('date', rangeEnd)
-    .order('date', { ascending: true })
+  const [{ data: summariesData }, { data: maxDateData }] = await Promise.all([
+    supabase
+      .from('summaries')
+      .select('*')
+      .gte('date', rangeStart)
+      .lte('date', rangeEnd)
+      .order('date', { ascending: true }),
+    supabase.from('summaries').select('date').order('date', { ascending: false }).limit(1),
+  ])
 
   const summaries = {
     data: summariesData,
-  } as unknown as SummariesResult
+    max_date: maxDateData?.[0]?.date ?? null,
+  } as unknown as SummariesResult & { max_date: string | null }
 
   return json(summaries)
 }

--- a/src/routes/api/supabase/summaries/server.spec.ts
+++ b/src/routes/api/supabase/summaries/server.spec.ts
@@ -1,0 +1,65 @@
+import type { RequestEvent } from './$types'
+import { describe, expect, it, vi } from 'vitest'
+import { GET } from './+server'
+
+const MAX_DATE = '2024-03-15'
+
+const mockSupabase = {
+  from: () => ({
+    select: (fields: string) => {
+      // Max-date query selects 'date' only; range query selects '*'
+      if (fields === 'date') {
+        return {
+          order: () => ({ limit: () => Promise.resolve({ data: [{ date: MAX_DATE }] }) }),
+        }
+      }
+      return {
+        gte: () => ({
+          lte: () => ({
+            order: () => Promise.resolve({ data: [] }),
+          }),
+        }),
+      }
+    },
+  }),
+}
+
+describe('GET /api/supabase/summaries', () => {
+  it('includes max_date in the response from a global MAX query', async () => {
+    const event = {
+      url: new URL('http://localhost/api/supabase/summaries?range=Last+7+Days'),
+      locals: { supabase: mockSupabase },
+    }
+    const response = await GET(event as unknown as RequestEvent)
+    const result = await response.json()
+    expect(result.max_date).toBe(MAX_DATE)
+  })
+
+  it('sets max_date to null when summaries table is empty', async () => {
+    const emptySupabase = {
+      from: () => ({
+        select: (fields: string) => {
+          if (fields === 'date') {
+            return {
+              order: () => ({ limit: () => Promise.resolve({ data: [] }) }),
+            }
+          }
+          return {
+            gte: () => ({
+              lte: () => ({
+                order: () => Promise.resolve({ data: [] }),
+              }),
+            }),
+          }
+        },
+      }),
+    }
+    const event = {
+      url: new URL('http://localhost/api/supabase/summaries'),
+      locals: { supabase: emptySupabase },
+    }
+    const response = await GET(event as unknown as RequestEvent)
+    const result = await response.json()
+    expect(result.max_date).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds \`max_date\` to the summaries route response via a global \`MAX(date)\` query (independent of the range filter)
- Displays \"Data through [date]\" in the dashboard header — hidden when \`max_date\` is null (empty table)
- Both Supabase queries run concurrently via \`Promise.all\` — no extra round-trip

## Test plan

- [x] Red: unit test asserting \`max_date\` present in route response (committed before green)
- [x] Green: \`server.spec.ts\` passes with mocked Supabase returning known MAX date
- [x] Null case covered: empty table → \`max_date: null\` → heading suppressed in template
- [x] Pre-existing failing tests (\`page.spec.ts\`, \`BreakdownChart.spec.ts\` timeout) not introduced by this ticket — verified by comparing against base branch

## CodeRabbit follow-up (eaaf371)

**Finding 1 — Major (patched):** Supabase query errors were ignored; both Promise.all results now checked for \`.error\`, returning HTTP 500 instead of silently passing \`null\` data to the frontend (which would throw a TypeError in \`summaries.data.reduce\`).

**Finding 2 — Nitpick (patched):** Replaced \`as unknown as SummariesResult & { max_date: string | null }\` with an exported \`SummariesApiResponse\` type. \`+page.server.ts\` now casts to \`SummariesApiResponse\` so \`max_date\` flows through the load function without a second inline re-cast in \`+page.svelte\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Late review follow-up (2026-05-04)

- Re-triaged CodeRabbit against the current head `eaaf371` and base `agents/p4-03-ai-section-redesign`
- No additional actionable findings remain
- The prior inline CodeRabbit thread is already patched, outdated, and resolved on GitHub
