### PR TITLE
feat(P4.05): custom date range picker

### DIFF
--- a/src/lib/components/DateRangeSelect.svelte
+++ b/src/lib/components/DateRangeSelect.svelte
@@ -1,13 +1,18 @@
 <script lang="ts">
   import { ApiEndpoint, WakaApiRange, WakaApiRangePrompt } from '$lib/constants'
+  import { customDateRange } from '$lib/stores/customDateRange'
   import { profile } from '$lib/stores/profile'
   import { selectedRange } from '$lib/stores/selectedRange'
   import { afterUpdate, createEventDispatcher } from 'svelte'
+  import dayjs from 'dayjs'
 
   const dispatch = createEventDispatcher()
 
+  const today = dayjs().format('YYYY-MM-DD')
+
   afterUpdate(async () => {
     if ($profile === undefined) return
+    if ($selectedRange === WakaApiRange.Custom) return
 
     if ($profile?.range !== $selectedRange && $selectedRange !== WakaApiRangePrompt) {
       try {
@@ -24,17 +29,51 @@
       }
     }
   })
+
+  function onRangeChange() {
+    if ($selectedRange !== WakaApiRange.Custom) {
+      customDateRange.set({ start: null, end: null })
+    }
+  }
+
+  function onCustomDateChange() {
+    if ($customDateRange.start && $customDateRange.end) {
+      dispatch('wakarange')
+    }
+  }
 </script>
 
-<select
-  class="select-accent select w-full bg-neutral-focus text-accent sm:w-fit"
-  bind:value={$selectedRange}
-  title="Select date range"
->
-  <option disabled selected>Pick a range</option>
-  {#each Object.values(WakaApiRange) as range (range)}
-    <option value={range}>
-      {range}
-    </option>
-  {/each}
-</select>
+<div class="flex flex-wrap items-center gap-2">
+  <select
+    class="select-accent select w-full bg-neutral-focus text-accent sm:w-fit"
+    bind:value={$selectedRange}
+    on:change={onRangeChange}
+    title="Select date range"
+  >
+    <option disabled selected>Pick a range</option>
+    {#each Object.values(WakaApiRange) as range (range)}
+      <option value={range}>
+        {range}
+      </option>
+    {/each}
+  </select>
+
+  {#if $selectedRange === WakaApiRange.Custom}
+    <input
+      type="date"
+      class="input input-bordered input-accent bg-neutral-focus text-accent"
+      max={today}
+      bind:value={$customDateRange.start}
+      on:change={onCustomDateChange}
+      aria-label="Start date"
+    />
+    <input
+      type="date"
+      class="input input-bordered input-accent bg-neutral-focus text-accent"
+      max={today}
+      bind:value={$customDateRange.end}
+      on:change={onCustomDateChange}
+      aria-label="End date"
+    />
+  {/if}
+</div>

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -21,6 +21,7 @@ export const WakaApiRange = {
   This_Week: 'This Week',
   This_Month: 'This Month',
   Last_Month: 'Last Month',
+  Custom: 'Custom',
 } as const
 
 export type WakaApiRange = typeof WakaApiRange

--- a/src/lib/helpers/buildSummariesUrl.spec.ts
+++ b/src/lib/helpers/buildSummariesUrl.spec.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest'
+import { buildSummariesUrl } from './buildSummariesUrl'
+import { ApiEndpoint, WakaApiRange } from '$lib/constants'
+
+describe('buildSummariesUrl', () => {
+  it('uses range param for named ranges', () => {
+    const url = buildSummariesUrl(WakaApiRange.Last_7_Days, null, null)
+    expect(url).toBe(`${ApiEndpoint.SupabaseSummaries}?range=Last+7+Days`)
+  })
+
+  it('uses start and end params for Custom range when both are set', () => {
+    const url = buildSummariesUrl('Custom', '2024-01-01', '2024-01-31')
+    expect(url).toBe(`${ApiEndpoint.SupabaseSummaries}?start=2024-01-01&end=2024-01-31`)
+  })
+
+  it('falls back to range param when Custom is selected but dates are null', () => {
+    const url = buildSummariesUrl('Custom', null, null)
+    expect(url).toBe(`${ApiEndpoint.SupabaseSummaries}?range=Custom`)
+  })
+
+  it('falls back to range param when Custom is selected but start is null', () => {
+    const url = buildSummariesUrl('Custom', null, '2024-01-31')
+    expect(url).toBe(`${ApiEndpoint.SupabaseSummaries}?range=Custom`)
+  })
+
+  it('falls back to range param when Custom is selected but end is null', () => {
+    const url = buildSummariesUrl('Custom', '2024-01-01', null)
+    expect(url).toBe(`${ApiEndpoint.SupabaseSummaries}?range=Custom`)
+  })
+})

--- a/src/lib/helpers/buildSummariesUrl.ts
+++ b/src/lib/helpers/buildSummariesUrl.ts
@@ -1,0 +1,13 @@
+import { ApiEndpoint } from '$lib/constants'
+
+export function buildSummariesUrl(
+  range: string,
+  start: string | null,
+  end: string | null,
+): string {
+  if (range === 'Custom' && start && end) {
+    return `${ApiEndpoint.SupabaseSummaries}?start=${start}&end=${end}`
+  }
+  const params = new URLSearchParams({ range })
+  return `${ApiEndpoint.SupabaseSummaries}?${params}`
+}

--- a/src/lib/stores/customDateRange.spec.ts
+++ b/src/lib/stores/customDateRange.spec.ts
@@ -1,0 +1,28 @@
+import { get } from 'svelte/store'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { customDateRange } from './customDateRange'
+
+describe('customDateRange store', () => {
+  beforeEach(() => {
+    customDateRange.set({ start: null, end: null })
+  })
+
+  it('has initial state { start: null, end: null }', () => {
+    expect(get(customDateRange)).toEqual({ start: null, end: null })
+  })
+
+  it('updates start date', () => {
+    customDateRange.set({ start: '2024-01-01', end: null })
+    expect(get(customDateRange)).toEqual({ start: '2024-01-01', end: null })
+  })
+
+  it('updates end date', () => {
+    customDateRange.set({ start: null, end: '2024-01-31' })
+    expect(get(customDateRange)).toEqual({ start: null, end: '2024-01-31' })
+  })
+
+  it('updates both start and end', () => {
+    customDateRange.set({ start: '2024-01-01', end: '2024-01-31' })
+    expect(get(customDateRange)).toEqual({ start: '2024-01-01', end: '2024-01-31' })
+  })
+})

--- a/src/lib/stores/customDateRange.ts
+++ b/src/lib/stores/customDateRange.ts
@@ -1,0 +1,6 @@
+import { writable } from 'svelte/store'
+
+export const customDateRange = writable<{ start: string | null; end: string | null }>({
+  start: null,
+  end: null,
+})

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -12,8 +12,10 @@
   import AiLinesPieChart from '$lib/components/AiLinesPieChart/AiLinesPieChart.svelte'
   import AiTokenBarChart from '$lib/components/AiTokenBarChart/AiTokenBarChart.svelte'
   import TimelineChart from '$lib/components/TimelineChart/TimelineChart.svelte'
-  import { ApiEndpoint, WakaApiRange, type ValueOf } from '$lib/constants'
+  import { WakaApiRange, type ValueOf } from '$lib/constants'
+  import { buildSummariesUrl } from '$lib/helpers/buildSummariesUrl'
   import { DateFormat } from '$lib/helpers/timeHelpers'
+  import { customDateRange } from '$lib/stores/customDateRange'
   import { loading } from '$lib/stores/loading'
   import { selectedRange } from '$lib/stores/selectedRange'
   import dayjs from 'dayjs'
@@ -61,9 +63,8 @@
   const onWakaRange = async () => {
     loading.on()
     try {
-      summaries = await fetch(`${ApiEndpoint.SupabaseSummaries}?range=${$selectedRange}`).then(
-        (response) => response.json(),
-      )
+      const url = buildSummariesUrl($selectedRange, $customDateRange.start, $customDateRange.end)
+      summaries = await fetch(url).then((response) => response.json())
     } finally {
       loading.off()
     }

--- a/src/routes/api/supabase/summaries/+server.ts
+++ b/src/routes/api/supabase/summaries/+server.ts
@@ -7,19 +7,18 @@ import dayjs from 'dayjs'
 export const GET: RequestHandler = async ({ url, locals: { supabase } }) => {
   const start = url.searchParams.get('start') ?? ''
   const end = url.searchParams.get('end') ?? ''
-  let range = url.searchParams.get('range') ?? WakaApiRange.Last_7_Days_From_Yesterday
+  const range = url.searchParams.get('range') ?? WakaApiRange.Last_7_Days_From_Yesterday
 
-  // start and end take precedence over range
-  if (start && end) {
-    range = ''
-  }
-
-  const rangeStart = dayjs()
-    .utc()
-    .subtract(WakaToShortcutApiRange[range as keyof typeof WakaToShortcutApiRange], 'd')
-    .format(DateFormat.Query)
-  const rangeEnd =
-    range === WakaApiRange.Yesterday || range === WakaApiRange.Last_7_Days_From_Yesterday
+  const hasCustomRange = Boolean(start && end)
+  const rangeStart = hasCustomRange
+    ? start
+    : dayjs()
+        .utc()
+        .subtract(WakaToShortcutApiRange[range as keyof typeof WakaToShortcutApiRange], 'd')
+        .format(DateFormat.Query)
+  const rangeEnd = hasCustomRange
+    ? end
+    : range === WakaApiRange.Yesterday || range === WakaApiRange.Last_7_Days_From_Yesterday
       ? dayjs().utc().subtract(1, 'd').format(DateFormat.Query)
       : dayjs().utc().format(DateFormat.Query)
 

--- a/src/routes/api/supabase/summaries/server.spec.ts
+++ b/src/routes/api/supabase/summaries/server.spec.ts
@@ -62,4 +62,35 @@ describe('GET /api/supabase/summaries', () => {
     const result = await response.json()
     expect(result.max_date).toBeNull()
   })
+
+  it('uses start and end query params when both are provided', async () => {
+    const gte = vi.fn().mockReturnValue({
+      lte: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({ data: [] }),
+      }),
+    })
+    const customRangeSupabase = {
+      from: () => ({
+        select: (fields: string) => {
+          if (fields === 'date') {
+            return {
+              order: () => ({ limit: () => Promise.resolve({ data: [{ date: MAX_DATE }] }) }),
+            }
+          }
+          return { gte }
+        },
+      }),
+    }
+    const event = {
+      url: new URL(
+        'http://localhost/api/supabase/summaries?range=Last+7+Days&start=2024-01-01&end=2024-01-31',
+      ),
+      locals: { supabase: customRangeSupabase },
+    }
+
+    await GET(event as unknown as RequestEvent)
+
+    expect(gte).toHaveBeenCalledWith('date', '2024-01-01')
+    expect(gte.mock.results[0]?.value.lte).toHaveBeenCalledWith('date', '2024-01-31')
+  })
 })


### PR DESCRIPTION
## Summary

- Adds `WakaApiRange.Custom` entry — does not appear in `WakaToShortcutApiRange`, bypasses it entirely
- New `customDateRange` writable store holds `{ start: string | null, end: string | null }`
- `DateRangeSelect` renders two native `<input type="date">` elements (with `max=today`) when Custom is selected; dispatches `wakarange` once both dates are set
- Profile sync skips the Supabase write when `$selectedRange === 'Custom'`
- Switching away from Custom clears the store (no stale dates persist)
- `buildSummariesUrl` helper constructs `?start=&end=` for Custom (both dates set) or `?range=` for all other values
- All existing named ranges behave identically to pre-phase behavior

## Test plan

- [x] Red: failing tests for `customDateRange` store initial state + mutations
- [x] Red: failing tests for `buildSummariesUrl` — range vs start/end params, null fallback cases
- [x] Green: all 9 new tests pass; 87 total (0 regressions)
- [x] Type check: 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)